### PR TITLE
Fix reference to using the Arrow IPC format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 This package is a C# wrapper around [delta-rs](https://github.com/delta-io/delta-rs/tree/rust-v0.17.0).
 
 It uses the [tokio-rs](https://tokio.rs/) runtime to provide asynchronous behavior. This allows the usage of .NET Tasks and async/await to take advantage of the same behavior provided by the underlying rust library.
-This library also takes advantage of the [Apache Arrow](https://github.com/apache/arrow/blob/main/csharp/README.md) C# IPC formats to minimize the amount of copying required to move data between runtimes.
+This library also takes advantage of the [Apache Arrow](https://github.com/apache/arrow/blob/main/csharp/README.md) [C Data Interface](https://arrow.apache.org/docs/format/CDataInterface.html) to minimize the amount of copying required to move data between runtimes.
 
 ![alt text](/media/images/delta-dot-net-pkg.png "Using a Rust bridge library with .NET p/invoke")
 


### PR DESCRIPTION
The README says this project uses the Arrow IPC format, but it looks like this is incorrect, it actually uses the C Data Interface for exchange of Arrow data between Rust and .NET (which actually allows zero copy, unlike the IPC format)