### PR TITLE
feat: Make ITable async

### DIFF
--- a/examples/local/Program.cs
+++ b/examples/local/Program.cs
@@ -104,10 +104,10 @@ public class Program
 
             Console.WriteLine($"Table version after transaction: {table.Version()}");
 
-            Apache.Arrow.Table readTable = table.ReadAsArrowTable();
+            Apache.Arrow.Table readTable = await table.ReadAsArrowTableAsync(CancellationToken.None);
             Console.WriteLine(readTable.ToString());
             
-            DataFrame df = table.ReadAsDataFrame();
+            DataFrame df = await table.ReadAsDataFrameAsync(CancellationToken.None);
             Console.WriteLine(df.ToMarkdown());
         }
     }

--- a/src/DeltaLake/Interfaces/ITable.cs
+++ b/src/DeltaLake/Interfaces/ITable.cs
@@ -137,15 +137,17 @@ namespace DeltaLake.Interfaces
         /// <summary>
         /// Read the delta table and return as <see cref="Apache.Arrow.Table"/>.
         /// </summary>
-        Apache.Arrow.Table ReadAsArrowTable();
+        /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken">cancellation token</see>.</param>
+        Task<Apache.Arrow.Table> ReadAsArrowTableAsync(CancellationToken cancellationToken);
 
         /// <summary>
         /// Read the delta table and return as a <see cref="DataFrame"/>.
         /// </summary>
+        /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken">cancellation token</see>.</param>
         /// <remarks>
         /// This loads the entire table into memory.
         /// </remarks>
-        DataFrame ReadAsDataFrame();
+        Task<DataFrame> ReadAsDataFrameAsync(CancellationToken cancellationToken);
 
         #endregion Read Operations
 

--- a/src/DeltaLake/Kernel/Shim/Async/SyncToAsyncShim.cs
+++ b/src/DeltaLake/Kernel/Shim/Async/SyncToAsyncShim.cs
@@ -1,0 +1,61 @@
+// -----------------------------------------------------------------------------
+// <summary>
+// A shim for turning synchronous operations to be asynchronous and cancellable.
+// </summary>
+//
+// <copyright company="The Delta Lake Project Authors">
+// Copyright (2024) The Delta Lake Project Authors.  All rights reserved.
+// Licensed under the Apache license. See LICENSE file in the project root for full license information.
+// </copyright>
+// -----------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DeltaLake.Kernel.Shim.Async
+{
+    /// <summary>
+    /// Uses <see cref="TaskCompletionSource"/> to shim async operations.
+    /// </summary>
+    internal static class SyncToAsyncShim
+    {
+        /// <summary>
+        /// Converts a synchronous operation to a cancellable asynchronous
+        /// operation.
+        /// </summary>
+        /// <param name="action">Action to invoke.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <typeparam name="T">Type of the result.</typeparam>
+        internal static async Task<T> ExecuteAsync<T>(
+            Func<T> action,
+            CancellationToken cancellationToken
+        )
+        {
+            var tsc = new TaskCompletionSource<T>();
+
+            _ = Task.Run(
+                () =>
+                {
+                    try
+                    {
+                        if (cancellationToken.IsCancellationRequested)
+                        {
+                            tsc.TrySetCanceled(cancellationToken);
+                            return;
+                        }
+
+                        tsc.TrySetResult(action());
+                    }
+                    catch (Exception ex)
+                    {
+                        tsc.TrySetException(ex);
+                    }
+                },
+                cancellationToken
+            );
+
+            return await tsc.Task.ConfigureAwait(false);
+        }
+    }
+}

--- a/src/DeltaLake/Kernel/Shim/Async/SyncToAsyncShim.cs
+++ b/src/DeltaLake/Kernel/Shim/Async/SyncToAsyncShim.cs
@@ -32,31 +32,7 @@ namespace DeltaLake.Kernel.Shim.Async
             CancellationToken cancellationToken
         )
         {
-            var tsc = new TaskCompletionSource<T>();
-
-            _ = Task.Run(
-                () =>
-                {
-                    try
-                    {
-                        if (cancellationToken.IsCancellationRequested)
-                        {
-                            tsc.TrySetCanceled(cancellationToken);
-                            return;
-                        }
-
-                        tsc.TrySetResult(action());
-                    }
-                    catch (Exception ex)
-                    {
-                        tsc.TrySetException(ex);
-                        throw;
-                    }
-                },
-                cancellationToken
-            );
-
-            return await tsc.Task.ConfigureAwait(false);
+            return await Task.Run(() => action(), cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/DeltaLake/Kernel/Shim/Async/SyncToAsyncShim.cs
+++ b/src/DeltaLake/Kernel/Shim/Async/SyncToAsyncShim.cs
@@ -50,6 +50,7 @@ namespace DeltaLake.Kernel.Shim.Async
                     catch (Exception ex)
                     {
                         tsc.TrySetException(ex);
+                        throw;
                     }
                 },
                 cancellationToken

--- a/src/DeltaLake/Table/DeltaTable.cs
+++ b/src/DeltaLake/Table/DeltaTable.cs
@@ -118,10 +118,13 @@ namespace DeltaLake.Table
         }
 
         /// <inheritdoc/>
-        public Apache.Arrow.Table ReadAsArrowTable() => this.table.ReadAsArrowTable();
+        public async Task<Apache.Arrow.Table> ReadAsArrowTableAsync(
+            CancellationToken cancellationToken
+        ) => await this.table.ReadAsArrowTableAsync(cancellationToken).ConfigureAwait(false);
 
         /// <inheritdoc/>
-        public DataFrame ReadAsDataFrame() => this.table.ReadAsDataFrame();
+        public async Task<DataFrame> ReadAsDataFrameAsync(CancellationToken cancellationToken) =>
+            await this.table.ReadAsDataFrameAsync(cancellationToken).ConfigureAwait(false);
 
         /// <inheritdoc/>
         public async Task InsertAsync(

--- a/tests/DeltaLake.Tests/Table/KernelTests.cs
+++ b/tests/DeltaLake.Tests/Table/KernelTests.cs
@@ -149,8 +149,8 @@ public class KernelTests
                     {
                         // Exercise: Reads via Kernel
                         //
-                        Apache.Arrow.Table arrowTable = threadIsolatedTable.ReadAsArrowTable();
-                        DataFrame dataFrame = threadIsolatedTable.ReadAsDataFrame();
+                        Apache.Arrow.Table arrowTable = await threadIsolatedTable.ReadAsArrowTableAsync(default);
+                        DataFrame dataFrame = await threadIsolatedTable.ReadAsDataFrameAsync(default);
                         string stringResult = dataFrame.ToMarkdown();
 
                         // Validate: Data Integrity


### PR DESCRIPTION
# Why this change is needed

This PR makes a couple Kernel based read methods synchronous to asynchronous, which makes the public facing interface - `DeltaLake.Interfaces.ITable` - completely asynchronous.

See convo [here](https://github.com/delta-incubator/delta-dotnet/pull/89#issuecomment-2400354360) for more context.

Closes issues: 
* https://github.com/delta-incubator/delta-dotnet/issues/91 - the work item
* https://github.com/delta-incubator/delta-dotnet/issues/92 - indirectly, since we can publish the Nuget now with a stable interface

# How

- A `SyncToAsyncShim` that wraps any typed delegate

# Test

- Ran unit tests
- Ran example app:
   
   ![image](https://github.com/user-attachments/assets/1d86f985-cb05-4032-a088-0fb54e992a30)

  
