### PR TITLE
fix: merge clause parsing was incorrect for `WHEN MATCHED THEN DELETE`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.22.3</Version>
+    <Version>0.22.3.1</Version>
     <!--
       .NET does not allow the above version format for AssemblyVersion, and this
       is the version used in gRPC headers. The format is
@@ -28,7 +28,7 @@
       and 0.2.0 then is 0.2.0.5. But if there is no prerelease version, just
       leave revision off.
     -->
-    <AssemblyVersion>0.22.3</AssemblyVersion>
+    <AssemblyVersion>0.22.3.1</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DeltaLake/Bridge/src/table.rs
+++ b/src/DeltaLake/Bridge/src/table.rs
@@ -734,7 +734,7 @@ pub extern "C" fn table_merge(
                             make_update!(update, predicate, assignments)
                         }),
                         crate::sql::MergeClause::MatchedDelete(predicate) => mb
-                            .when_not_matched_by_source_delete(|delete| match predicate {
+                            .when_matched_delete(|delete| match predicate {
                                 Some(predicate) => delete.predicate(predicate.to_string()),
                                 None => delete,
                             }),

--- a/tests/DeltaLake.Tests/Table/MergeTests.cs
+++ b/tests/DeltaLake.Tests/Table/MergeTests.cs
@@ -199,19 +199,20 @@ public class MergeTests
     }
 
     [Fact]
-    public async Task Merge_When_Matched_Delete_Test() {
-      const string query = @"MERGE INTO mytable USING newdata
+    public async Task Merge_When_Matched_Delete_Test()
+    {
+        const string query = @"MERGE INTO mytable USING newdata
                               ON mytable.test = newdata.test
                               WHEN MATCHED THEN DELETE;";
-      await BaseMergeTest(query, batches =>
-        {
-            var column1 = batches.SelectMany(batch => ((Int32Array)batch.Column(0)).Values.ToArray()).OrderBy(i => i).ToArray();
-            Assert.True(column1.SequenceEqual([0, 1, 2, 3, 4]));
-            var column2 = batches.SelectMany(batch => ((IReadOnlyList<string>)(StringArray)batch.Column(1)).ToArray()).OrderBy(i => i).ToArray();
-            Assert.True(column2.SequenceEqual(["0", "1", "2", "3", "4",]));
-            var column3 = batches.SelectMany(batch => ((Int64Array)batch.Column(2)).Values.ToArray()).OrderBy(i => i).ToArray();
-            Assert.True(column3.SequenceEqual([0L, 1L, 2L, 3L, 4L]));
-        });
+        await BaseMergeTest(query, batches =>
+          {
+              var column1 = batches.SelectMany(batch => ((Int32Array)batch.Column(0)).Values.ToArray()).OrderBy(i => i).ToArray();
+              Assert.True(column1.SequenceEqual([0, 1, 2, 3, 4]));
+              var column2 = batches.SelectMany(batch => ((IReadOnlyList<string>)(StringArray)batch.Column(1)).ToArray()).OrderBy(i => i).ToArray();
+              Assert.True(column2.SequenceEqual(["0", "1", "2", "3", "4",]));
+              var column3 = batches.SelectMany(batch => ((Int64Array)batch.Column(2)).Values.ToArray()).OrderBy(i => i).ToArray();
+              Assert.True(column3.SequenceEqual([0L, 1L, 2L, 3L, 4L]));
+          });
     }
 
     private async Task BaseMergeTest(string query, Action<IReadOnlyList<RecordBatch>> assertions)

--- a/tests/DeltaLake.Tests/Table/MergeTests.cs
+++ b/tests/DeltaLake.Tests/Table/MergeTests.cs
@@ -198,6 +198,22 @@ public class MergeTests
         Assert.Equal(version, table.Version());
     }
 
+    [Fact]
+    public async Task Merge_When_Matched_Delete_Test() {
+      const string query = @"MERGE INTO mytable USING newdata
+                              ON mytable.test = newdata.test
+                              WHEN MATCHED THEN DELETE;";
+      await BaseMergeTest(query, batches =>
+        {
+            var column1 = batches.SelectMany(batch => ((Int32Array)batch.Column(0)).Values.ToArray()).OrderBy(i => i).ToArray();
+            Assert.True(column1.SequenceEqual([0, 1, 2, 3, 4]));
+            var column2 = batches.SelectMany(batch => ((IReadOnlyList<string>)(StringArray)batch.Column(1)).ToArray()).OrderBy(i => i).ToArray();
+            Assert.True(column2.SequenceEqual(["0", "1", "2", "3", "4",]));
+            var column3 = batches.SelectMany(batch => ((Int64Array)batch.Column(2)).Values.ToArray()).OrderBy(i => i).ToArray();
+            Assert.True(column3.SequenceEqual([0L, 1L, 2L, 3L, 4L]));
+        });
+    }
+
     private async Task BaseMergeTest(string query, Action<IReadOnlyList<RecordBatch>> assertions)
     {
         var pair = await TableHelpers.SetupTable($"memory://{Guid.NewGuid():N}", 10);


### PR DESCRIPTION
fixes #113