### PR TITLE
chore: dispose engines in tests to reduce peak thread count

### DIFF
--- a/tests/DeltaLake.Tests/Table/CheckpointTests.cs
+++ b/tests/DeltaLake.Tests/Table/CheckpointTests.cs
@@ -81,6 +81,7 @@ namespace DeltaLake.Tests.Table
         public async Task Memory_CheckpointAsync_Throws_NotSupported()
         {
             var data = await TableHelpers.SetupTable($"memory:///{Guid.NewGuid():N}", 0);
+            using var engine = data.engine;
             using var table = data.table;
             var ex = await Assert.ThrowsAsync<NotSupportedException>(
                 async () => await table.CheckpointAsync(CancellationToken.None));
@@ -94,6 +95,7 @@ namespace DeltaLake.Tests.Table
             try
             {
                 var data = await TableHelpers.SetupTable(DirectoryHelpers.ToFileUri(info.FullName), 0);
+                using var engine = data.engine;
                 using var table = data.table;
                 var schema = table.Schema();
                 var options = new InsertOptions { SaveMode = SaveMode.Append };
@@ -135,6 +137,7 @@ namespace DeltaLake.Tests.Table
                 // Build a table with v0..v8.
                 {
                     var data = await TableHelpers.SetupTable(path, 0);
+                    using var seedEngine = data.engine;
                     using var seed = data.table;
                     var schema = seed.Schema();
                     var insert = new InsertOptions { SaveMode = SaveMode.Append };
@@ -220,6 +223,7 @@ namespace DeltaLake.Tests.Table
                 // Writer builds v0..v8.
                 {
                     var data = await TableHelpers.SetupTable(path, 0);
+                    using var seedEngine = data.engine;
                     using var seed = data.table;
                     var schema = seed.Schema();
                     var insert = new InsertOptions { SaveMode = SaveMode.Append };
@@ -266,6 +270,7 @@ namespace DeltaLake.Tests.Table
             {
                 var path = DirectoryHelpers.ToFileUri(info.FullName);
                 var data = await TableHelpers.SetupTable(path, 0);
+                using var engine = data.engine;
                 using var table = data.table;
                 var schema = table.Schema();
                 var options = new InsertOptions { SaveMode = SaveMode.Append };
@@ -346,6 +351,7 @@ namespace DeltaLake.Tests.Table
             Func<ITable, Task> more)
         {
             var data = await TableHelpers.SetupTable(path, 0);
+            using var engine = data.engine;
             using var table = data.table;
             var schema = table.Schema();
             var options = new InsertOptions
@@ -370,6 +376,7 @@ namespace DeltaLake.Tests.Table
             {
                 var path = DirectoryHelpers.ToFileUri(info.FullName);
                 var data = await TableHelpers.SetupTable(path, 1);
+                using var engine = data.engine;
                 using var table = data.table;
 
                 // The parameterless default (CheckpointFormat.Auto) matches the pre-options behavior.
@@ -392,6 +399,7 @@ namespace DeltaLake.Tests.Table
             {
                 var path = DirectoryHelpers.ToFileUri(info.FullName);
                 var data = await TableHelpers.SetupTable(path, 1);
+                using var engine = data.engine;
                 using var table = data.table;
 
                 await table.CheckpointAsync(
@@ -415,6 +423,7 @@ namespace DeltaLake.Tests.Table
             {
                 var path = DirectoryHelpers.ToFileUri(info.FullName);
                 var data = await TableHelpers.SetupTable(path, 1);
+                using var engine = data.engine;
                 using var table = data.table;
 
                 // The table does not enable the v2Checkpoint feature, so forcing a V2 checkpoint

--- a/tests/DeltaLake.Tests/Table/ConstraintTests.cs
+++ b/tests/DeltaLake.Tests/Table/ConstraintTests.cs
@@ -45,6 +45,7 @@ namespace DeltaLake.Tests.Table
         public async Task Invalid_Constraint_Test()
         {
             var tableParts = await TableHelpers.SetupTable($"memory:///{Guid.NewGuid():N}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
             await Assert.ThrowsAsync<DeltaRuntimeException>(() => table.AddConstraintsAsync(
                 new Dictionary<string, string>
@@ -59,6 +60,7 @@ namespace DeltaLake.Tests.Table
         public async Task Add_Constraint_Cancellation_Test()
         {
             var tableParts = await TableHelpers.SetupTable($"memory:///{Guid.NewGuid():N}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
             var version = table.Version();
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => table.AddConstraintsAsync(
@@ -75,6 +77,7 @@ namespace DeltaLake.Tests.Table
         public async Task Empty_Constraint_Test()
         {
             var tableParts = await TableHelpers.SetupTable($"memory:///{Guid.NewGuid():N}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
             var version = table.Version();
             await table.AddConstraintsAsync(

--- a/tests/DeltaLake.Tests/Table/CreateWriteTransactionTests.cs
+++ b/tests/DeltaLake.Tests/Table/CreateWriteTransactionTests.cs
@@ -12,6 +12,7 @@ public class CreateWriteTransactionTests
         try
         {
             var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
 
             var initialVersion = table.Version();
@@ -94,6 +95,7 @@ public class CreateWriteTransactionTests
         try
         {
             var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
 
             var baseVersion = (long)table.Version()!;
@@ -132,6 +134,7 @@ public class CreateWriteTransactionTests
         try
         {
             var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
 
             await Assert.ThrowsAsync<DeltaConfigurationException>(
@@ -152,6 +155,7 @@ public class CreateWriteTransactionTests
         try
         {
             var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
 
             await Assert.ThrowsAsync<DeltaConfigurationException>(
@@ -172,6 +176,7 @@ public class CreateWriteTransactionTests
         try
         {
             var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
             var version = table.Version();
 
@@ -205,6 +210,7 @@ public class CreateWriteTransactionTests
         try
         {
             var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
 
             var actions = new List<AddAction>
@@ -237,6 +243,7 @@ public class CreateWriteTransactionTests
         try
         {
             var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
 
             var actions = new List<AddAction>
@@ -274,6 +281,7 @@ public class CreateWriteTransactionTests
         try
         {
             var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
 
             var actions = new List<AddAction>
@@ -309,6 +317,7 @@ public class CreateWriteTransactionTests
         try
         {
             var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
             var baseVersion = (long)table.Version()!;
 
@@ -342,6 +351,7 @@ public class CreateWriteTransactionTests
         try
         {
             var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
 
             var actions = new List<AddAction>
@@ -374,6 +384,7 @@ public class CreateWriteTransactionTests
         try
         {
             var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
 
             var actions = new List<AddAction>
@@ -416,6 +427,7 @@ public class CreateWriteTransactionTests
         try
         {
             var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
 
             var actions = new List<AddAction>
@@ -452,6 +464,7 @@ public class CreateWriteTransactionTests
         try
         {
             var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
 
             var actions = new List<AddAction>
@@ -483,6 +496,7 @@ public class CreateWriteTransactionTests
         try
         {
             var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
 
             var actions = new List<AddAction>
@@ -530,6 +544,7 @@ public class CreateWriteTransactionTests
         try
         {
             var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
 
             var actions = new List<AddAction>
@@ -572,6 +587,7 @@ public class CreateWriteTransactionTests
         try
         {
             var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
 
             var options = new CommitOptions
@@ -599,6 +615,7 @@ public class CreateWriteTransactionTests
         try
         {
             var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
 
             var baseVersion = (long)table.Version()!;
@@ -642,6 +659,7 @@ public class CreateWriteTransactionTests
         try
         {
             var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
 
             var options = new CommitOptions
@@ -705,6 +723,7 @@ public class CreateWriteTransactionTests
         try
         {
             var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
 
             var actions = new List<AddAction>
@@ -748,6 +767,7 @@ public class CreateWriteTransactionTests
         try
         {
             var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
 
             var txnVersion = await table.GetLatestTransactionVersionAsync(
@@ -769,6 +789,7 @@ public class CreateWriteTransactionTests
         try
         {
             var tableParts = await TableHelpers.SetupTable($"file://{info.FullName}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
 
             for (int i = 1; i <= 3; i++)

--- a/tests/DeltaLake.Tests/Table/DeleteTests.cs
+++ b/tests/DeltaLake.Tests/Table/DeleteTests.cs
@@ -91,6 +91,7 @@ public class DeleteTests
         bool cancelOp = false)
     {
         var data = await TableHelpers.SetupTable(path, length);
+        using var engine = data.engine;
         using var table = data.table;
         var token = cancelOp ? new CancellationToken(true) : CancellationToken.None;
         if (predicate == null)

--- a/tests/DeltaLake.Tests/Table/InsertTests.cs
+++ b/tests/DeltaLake.Tests/Table/InsertTests.cs
@@ -37,6 +37,7 @@ public class InsertTests
     public async Task Memory_Insert_Zero_Record_Count_Test()
     {
         var tableParts = await TableHelpers.SetupTable($"memory:///{Guid.NewGuid():N}", 0);
+        using var engine = tableParts.engine;
         using var table = tableParts.table;
         var version = table.Version();
         await table.InsertAsync([], table.Schema(), new InsertOptions(), CancellationToken.None);
@@ -47,6 +48,7 @@ public class InsertTests
     public async Task Insert_Stream_Test()
     {
         var tableParts = await TableHelpers.SetupTable($"memory:///{Guid.NewGuid():N}", 0);
+        using var engine = tableParts.engine;
         using var table = tableParts.table;
         var version = table.Version();
         var rb = new[] {
@@ -62,6 +64,7 @@ public class InsertTests
     public async Task Memory_Insert_Will_Cancel_Test()
     {
         var tableParts = await TableHelpers.SetupTable($"memory:///{Guid.NewGuid():N}", 0);
+        using var engine = tableParts.engine;
         using var table = tableParts.table;
         var version = table.Version();
         try
@@ -86,6 +89,7 @@ public class InsertTests
                 OverwriteSchema = true,
             };
             var tableParts = await TableHelpers.SetupTable($"memory:///{Guid.NewGuid():N}", 1, options);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
             var version = table.Version();
             await table.InsertAsync([], table.Schema(), new InsertOptions(), CancellationToken.None);
@@ -97,6 +101,7 @@ public class InsertTests
     private async Task BaseInsertTest(string path, int length)
     {
         var data = await TableHelpers.SetupTable(path, length);
+        using var engine = data.engine;
         using var table = data.table;
         var queryResult = table.QueryAsync(new SelectQuery("SELECT test FROM test WHERE test > 1")
         {
@@ -118,6 +123,7 @@ public class InsertTests
     private async Task StreamInsertTest(string path, int length)
     {
         var data = await TableHelpers.SetupTable(path, length);
+        using var engine = data.engine;
         using var table = data.table;
         var queryResult = table.QueryAsync(new SelectQuery("SELECT test FROM test WHERE test > 1")
         {

--- a/tests/DeltaLake.Tests/Table/LoadTests.cs
+++ b/tests/DeltaLake.Tests/Table/LoadTests.cs
@@ -12,6 +12,7 @@ public partial class LoadTests
     public async Task Memory_LoadVersionAsync_Throws_NotSupported()
     {
         var data = await TableHelpers.SetupTable($"memory:///{Guid.NewGuid():N}", 0);
+        using var engine = data.engine;
         using var table = data.table;
         var ex = await Assert.ThrowsAsync<NotSupportedException>(
             async () => await table.LoadVersionAsync(0, CancellationToken.None));
@@ -22,6 +23,7 @@ public partial class LoadTests
     public async Task Memory_LoadDateTimeAsync_Throws_NotSupported()
     {
         var data = await TableHelpers.SetupTable($"memory:///{Guid.NewGuid():N}", 0);
+        using var engine = data.engine;
         using var table = data.table;
         var ex = await Assert.ThrowsAsync<NotSupportedException>(
             async () => await table.LoadDateTimeAsync(0L, CancellationToken.None));

--- a/tests/DeltaLake.Tests/Table/MergeTests.cs
+++ b/tests/DeltaLake.Tests/Table/MergeTests.cs
@@ -157,6 +157,7 @@ public class MergeTests
             99
           )";
         var pair = await TableHelpers.SetupTable($"memory:///{Guid.NewGuid():N}", 10);
+        using var engine = pair.engine;
         using var table = pair.table;
         var allocator = new NativeMemoryAllocator();
         var enumerable = Enumerable.Range(5, 10);
@@ -181,6 +182,7 @@ public class MergeTests
     public async Task Merge_Zero_Record_Count_Test()
     {
         var tableParts = await TableHelpers.SetupTable($"memory:///{Guid.NewGuid():N}", 0);
+        using var engine = tableParts.engine;
         using var table = tableParts.table;
         var version = table.Version();
         await table.MergeAsync(@"MERGE INTO mytable USING newdata
@@ -219,6 +221,7 @@ public class MergeTests
     private async Task BaseMergeTest(string query, Action<IReadOnlyList<RecordBatch>> assertions)
     {
         var pair = await TableHelpers.SetupTable($"memory:///{Guid.NewGuid():N}", 10);
+        using var engine = pair.engine;
         using var table = pair.table;
         var allocator = new NativeMemoryAllocator();
         var enumerable = Enumerable.Range(5, 10);

--- a/tests/DeltaLake.Tests/Table/OptimizeTests.cs
+++ b/tests/DeltaLake.Tests/Table/OptimizeTests.cs
@@ -44,6 +44,7 @@ public sealed class OptimizeTests
     {
         using var source = new CancellationTokenSource(30_000);
         var data = await TableHelpers.SetupTable($"memory:///{Guid.NewGuid():N}", 10_000);
+        using var engine = data.engine;
         using var table = data.table;
 
         await table.OptimizeAsync(options, source.Token);

--- a/tests/DeltaLake.Tests/Table/QueryTests.cs
+++ b/tests/DeltaLake.Tests/Table/QueryTests.cs
@@ -9,6 +9,7 @@ public class QueryTests
     public async Task Query_Cancellation_Test()
     {
         var data = await TableHelpers.SetupTable($"memory:///{Guid.NewGuid():N}", 1);
+        using var engine = data.engine;
         using var table = data.table;
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
         {
@@ -29,6 +30,7 @@ public class QueryTests
     public async Task Query_Valid_Query_Params_Test(string queryText, string tableAlias)
     {
         var data = await TableHelpers.SetupTable($"memory:///{Guid.NewGuid():N}", 1);
+        using var engine = data.engine;
         using var table = data.table;
         var query = new SelectQuery(queryText)
         {
@@ -49,6 +51,7 @@ public class QueryTests
     public async Task Query_Invalid_Query_Params_Test(string queryText, string tableAlias)
     {
         var data = await TableHelpers.SetupTable($"memory:///{Guid.NewGuid():N}", 1);
+        using var engine = data.engine;
         using var table = data.table;
         await Assert.ThrowsAsync<DeltaRuntimeException>(async () =>
         {

--- a/tests/DeltaLake.Tests/Table/RestoreTests.cs
+++ b/tests/DeltaLake.Tests/Table/RestoreTests.cs
@@ -10,6 +10,7 @@ public class RestoreTests
     public async Task Restore_Cancellation_Test(bool useVersion)
     {
         var data = await TableHelpers.SetupTable($"memory:///{Guid.NewGuid():N}", 1);
+        using var engine = data.engine;
         using var table = data.table;
         var options = new RestoreOptions
         {

--- a/tests/DeltaLake.Tests/Table/StreamingInsertTests.cs
+++ b/tests/DeltaLake.Tests/Table/StreamingInsertTests.cs
@@ -20,6 +20,7 @@ public class StreamingInsertTests
     public async Task Memory_Insert_Stream_Of_Batches_Test(int batchCount, int rowsPerBatch)
     {
         var tableParts = await TableHelpers.SetupTable($"memory:///{Guid.NewGuid():N}", 0);
+        using var engine = tableParts.engine;
         using var table = tableParts.table;
         var version = table.Version();
 
@@ -38,6 +39,7 @@ public class StreamingInsertTests
         try
         {
             var tableParts = await TableHelpers.SetupTable($"file://{tempDir.FullName}", 0);
+            using var engine = tableParts.engine;
             using var table = tableParts.table;
             var version = table.Version();
 
@@ -63,6 +65,7 @@ public class StreamingInsertTests
     public async Task Insert_Stream_Producer_Error_Test(int failAfterBatches, SaveMode saveMode)
     {
         var tableParts = await TableHelpers.SetupTable($"memory:///{Guid.NewGuid():N}", 20);
+        using var engine = tableParts.engine;
         using var table = tableParts.table;
         var version = table.Version();
 
@@ -89,6 +92,7 @@ public class StreamingInsertTests
     public async Task Insert_Stream_Will_Cancel_Midway_Test()
     {
         var tableParts = await TableHelpers.SetupTable($"memory:///{Guid.NewGuid():N}", 0);
+        using var engine = tableParts.engine;
         using var table = tableParts.table;
         var version = table.Version();
 

--- a/tests/DeltaLake.Tests/Table/UpdateTests.cs
+++ b/tests/DeltaLake.Tests/Table/UpdateTests.cs
@@ -61,6 +61,7 @@ public class UpdateTests
     public async Task Update_Cancellation_Test()
     {
         var data = await TableHelpers.SetupTable($"memory:///{Guid.NewGuid():N}", 10);
+        using var engine = data.engine;
         using var table = data.table;
         var version = table.Version();
         try
@@ -81,6 +82,7 @@ public class UpdateTests
         long expectedTotal)
     {
         var data = await TableHelpers.SetupTable(path, length);
+        using var engine = data.engine;
         using var table = data.table;
         await table.UpdateAsync(query, CancellationToken.None);
         var queryResult = table.QueryAsync(new SelectQuery("select SUM(test) from test")

--- a/tests/DeltaLake.Tests/Table/VacuumTests.cs
+++ b/tests/DeltaLake.Tests/Table/VacuumTests.cs
@@ -24,6 +24,7 @@ public sealed class VacuumTests
     {
         using var source = new CancellationTokenSource(30_000);
         var data = await TableHelpers.SetupTable($"memory:///{Guid.NewGuid():N}", 10_000);
+        using var engine = data.engine;
         using var table = data.table;
 
         await table.VacuumAsync(options, source.Token);

--- a/tests/DeltaLake.Tests/Table/WriteReadSameHandleTests.cs
+++ b/tests/DeltaLake.Tests/Table/WriteReadSameHandleTests.cs
@@ -23,6 +23,7 @@ public class WriteReadSameHandleTests
             // SetupTable creates v0 and writes an initial commit at v1 (2 rows) into a real
             // parquet file at the table root.
             var data = await TableHelpers.SetupTable(path, 2);
+            using var engine = data.engine;
             using var table = data.table;
 
             // Read once to materialize + cache a kernel snapshot at v1.
@@ -79,6 +80,7 @@ public class WriteReadSameHandleTests
             var path = DirectoryHelpers.ToFileUri(info.FullName);
             // SetupTable creates v0 and writes an initial commit at v1 (1 row).
             var data = await TableHelpers.SetupTable(path, 1);
+            using var engine = data.engine;
             using var table = data.table;
             var schema = table.Schema();
             var options = new InsertOptions { SaveMode = SaveMode.Append };
@@ -117,6 +119,7 @@ public class WriteReadSameHandleTests
         {
             var path = DirectoryHelpers.ToFileUri(info.FullName);
             var data = await TableHelpers.SetupTable(path, 5);
+            using var engine = data.engine;
             using var table = data.table;
 
             // Two consecutive reads with no new commits: exercises the equal-version


### PR DESCRIPTION
I was running the tests in a container with a limit of 2048 PIDs and occasionally the tests would hang and log an error like:
```
thread 'tokio-rt-worker' (41928) panicked at /rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/std/src/thread/functions.rs:131:29:
failed to spawn thread: Os { code: 11, kind: WouldBlock, message: "Resource temporarily unavailable" }
```

Because the tokio runtimes in the engines were only shut down after garbage collection when the finalizer runs, the tokio worker threads were accumulating and sometimes hitting this limit.

Updating the tests to dispose the engine returned by `SetupTable` reduced the peak thread count from around 2k to about 700.

This issue is pretty specific to my environment and I could bump that limit, but I thought it's worth updating the tests to dispose the engines.